### PR TITLE
Removing quotation marks for Linux notifications

### DIFF
--- a/pynotifier/pynotifier.py
+++ b/pynotifier/pynotifier.py
@@ -62,8 +62,8 @@ class Notification:
 	def __send_linux(self):
 		import subprocess
 		command = [
-			'notify-send', '"{}"'.format(self.__title),
-			'"{}"'.format(self.__description),
+			'notify-send', '{}'.format(self.__title),
+			'{}'.format(self.__description),
 			'-u', self.__urgency,
 			'-t', '{}'.format(self.__duration * 1000)
 		]


### PR DESCRIPTION
Currently, quotation marks are added on the Title and Description strings but only for the Linux notifications. Removing these quotation marks for consistency sake.