### PR TITLE
Bug fix for requiring win10toast on a Windows machine

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,7 @@ AUTHOR = 'Yuriy Lisovskiy'
 REQUIRES_PYTHON = '>=3.6.0'
 VERSION = '0.1.0'
 
-REQUIRED = []
-
-if 'Windows' in platform.system():
-	REQUIRED.append('win10toast')
+REQUIRED = ["win10toast; platform_system=='Windows'"]
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
I've tried to send a notification using `py-notifier` on a Windows machine but then got the error below:

```bash
Python 3.8.6rc1 (tags/v3.8.6rc1:08bd63d, Sep  7 2020, 23:10:23) [MSC v.1927 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from pynotifier import Notification
>>> Notification("title", "description")
<pynotifier.pynotifier.Notification object at 0x00000211BC580AF0>
>>> Notification("title", "description").send()
Traceback (most recent call last):
  File "C:\Users\user\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pynotifier\pynotifier.py", line 77, in __send_windows
    import win10toast
ModuleNotFoundError: No module named 'win10toast'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\user\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pynotifier\pynotifier.py", line 57, in send
    self.__send_windows()
  File "C:\Users\user\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pynotifier\pynotifier.py", line 86, in __send_windows
    raise ImportError('notifications are not supported, can\'t import necessary library')
ImportError: notifications are not supported, can't import necessary library
```

So even though `win10toast` was mentioned in `install_requires` it wasn't being installed.
This pull request fixes that problem.