### PR TITLE
use non blocking subprocess call (linux); fixes #13

### DIFF
--- a/pynotifier/pynotifier.py
+++ b/pynotifier/pynotifier.py
@@ -88,7 +88,7 @@ class Notification:
         if self.__app_name is not None:
             command += ["-a", self.__app_name]
 
-        subprocess.call(command)
+        subprocess.Popen(command, shell=False)
 
     def send_windows(self):
         """Notify on windows with win10toast."""


### PR DESCRIPTION
as discussed in #13, this PR replaces the blocking subprocess call with a non blocking one.

Since we do care about the return value of the subprocess, there is no point to actually wait until it finishes.