### PR TITLE
Replace win10toast with WinToaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ pip install py-notifier
 
 ### Requirements
 #### Windows:
-[`win10toast`](https://github.com/jithurjacob/Windows-10-Toast-Notifications) - Python module
+[`WinToaster`](https://https://github.com/MaliciousFiles/WinToaster) - Python module
 #### Linux:
 `libnotify-bin` CLI tool (manual installation is required). For Ubuntu run:
 ```bash

--- a/pynotifier/pynotifier.py
+++ b/pynotifier/pynotifier.py
@@ -93,15 +93,15 @@ class Notification:
     def send_windows(self):
         """Notify on windows with win10toast."""
         try:
-            import win10toast
+            import wintoaster
 
-            win10toast.ToastNotifier().show_toast(
+            wintoaster.create_toast(
                 threaded=True,
                 title=self.__title,
                 msg=self.__description,
                 duration=self.__duration,
                 icon_path=self.__icon_path,
-            )
+            ).display()
         except ImportError:
             raise ImportError(
                 "notifications are not supported, can't import win10toast"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-win10toast==0.9; platform_system=='Windows'
+wintoaster==0.1; platform_system=='Windows'
 pync==2.0.3; platform_system=='Darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-wintoaster==0.1; platform_system=='Windows'
+WinToaster==0.1; platform_system=='Windows'
 pync==2.0.3; platform_system=='Darwin'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES_PYTHON = ">=3.6.0"
 VERSION = (0, 3, 0)
 
 REQUIRED = [
-    "win10toast==0.9; platform_system=='Windows'",
+    "WinToaster==0.1; platform_system=='Windows'",
     "pync==2.0.3; platform_system=='Darwin'",
 ]
 


### PR DESCRIPTION
Hello, I saw this library and thought it was cool, and even better has had a recent commit! I'd like to recommend you use my new module that I created when I found win10toast lacking. You have a lot more customization methods and one thing that I noticed you specifically use, is the `duration` parameter. win10toast unfortunately cannot change the duration of the toast, rather duration is more of a delay in the code. With my module, toasts can stay on screen for an actually variable amount of time along with some other features you can look through (sorry the documentation isn't up yet, but you can look through the code): [https://github.com/MaliciousFiles/WinToaster](https://github.com/MaliciousFiles/WinToaster), and on PyPi at [https://pypi.org/project/WinToaster/0.0.1](https://pypi.org/project/WinToaster/0.0.1). Another thing is that my module is still maintained, while I believe that win10toast is not. Lastly, though I don't know when this is going to happen as I have other projects, I'm planning on overhauling WinToaster to use WinRT which would allow a lot more customization as well as buttons.

I've taken the liberty to fix all of the calls and requirements to win10toast *that I saw*, but you should probably look through it to make sure I didn't miss anything.